### PR TITLE
Fix broken submodules: askthem branch rename, remove cartodb

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -185,7 +185,7 @@
 [submodule "apps/askthem"]
 	path = apps/askthem
 	url = git@github.com:opengovernment/askthem.git
-	branch = master
+	branch = main
 [submodule "apps/opengovernment"]
 	path = apps/opengovernment
 	url = git@github.com:opengovernment/opengovernment.git
@@ -289,10 +289,6 @@
 [submodule "apps/ror_ecommerce"]
 	path = apps/ror_ecommerce
 	url = git@github.com:drhenner/ror_ecommerce.git
-	branch = master
-[submodule "apps/cartodb"]
-	path = apps/cartodb
-	url = git@github.com:CartoDB/cartodb.git
 	branch = master
 [submodule "apps/classroom"]
 	path = apps/classroom

--- a/repos.md
+++ b/repos.md
@@ -132,9 +132,6 @@ Connect Any App to Any Service [https://github.com/nebulab/cangaroo](https://git
 The open LMS by Instructure, Inc. [https://github.com/instructure/canvas-lms/wiki](https://github.com/instructure/canvas-lms/wiki)  
 [https://github.com/instructure/canvas-lms](https://github.com/instructure/canvas-lms)
 
-### cartodb
-Location Intelligence & Data Visualization tool [http://carto.com](http://carto.com)  
-[https://github.com/CartoDB/cartodb](https://github.com/CartoDB/cartodb)
 
 ### case_file_editor
 An editor for digital case files.  


### PR DESCRIPTION
## Summary

- **askthem** (#14): `opengovernment/askthem` renamed its default branch `master` → `main`. Updated `.gitmodules` to track `main`.
- **cartodb** (#15): `CartoDB/cartodb` repo is gone/private — `git ls-remote` returns "Repository not found". Removed the submodule and `repos.md` entry.

Both confirmed live against the remotes before making any changes.

Closes #14, closes #15