### PR TITLE
Add otwarchive app

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -874,3 +874,7 @@
 [submodule "apps/pagecord"]
 	path = apps/pagecord
 	url = https://github.com/lylo/pagecord.git
+[submodule "apps/otwarchive"]
+	path = apps/otwarchive
+	url = git@github.com:otwcode/otwarchive.git
+	branch = master

--- a/repos.md
+++ b/repos.md
@@ -547,6 +547,10 @@ Your best weapon in the fight against outdated documentation. [http://orientatio
 Open Source Event Manager. An event management tool tailored to Free and Open Source Software conferences. [http://osem.io](http://osem.io)  
 [https://github.com/openSUSE/osem](https://github.com/openSUSE/osem)
 
+### otwarchive
+The OTW-Archive software is an open-source web application intended for hosting archives of fanworks, including fanfic, fanart, and fan vids. [https://archiveofourown.org](https://archiveofourown.org)  
+[https://github.com/otwcode/otwarchive](https://github.com/otwcode/otwarchive)
+
 ### pageflow
 Multimedia story telling for the web. [http://pageflow.io](http://pageflow.io)
 [https://github.com/codevise/pageflow](https://github.com/codevise/pageflow)


### PR DESCRIPTION
The OTW-Archive software is an open-source web application intended for hosting archives of fanworks, including fanfic, fanart, and fan vids.

https://github.com/otwcode/otwarchive

Found via @nateberkopec's Four Line Friday newsletter (suggested by @andyw8).

Closes #29