### PR TITLE
Add `bin/verify` script to check submodule repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ If you want to update all submodules to the absolute latest right now (without w
 - **`bin/update`** — Pull latest changes and update all submodules to their latest remote commits
 - **`bin/status`** — Show how many apps are initialized
 - **`bin/add`** — Add a new app or engine by GitHub URL (e.g. `bin/add https://github.com/user/repo`)
+- **`bin/verify`** — Check that each submodule repo still exists on GitHub and hasn't been moved or renamed (requires `gh` CLI)
 
 ## Contributing
 

--- a/bin/verify
+++ b/bin/verify
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+################################################################################
+# Real World Rails Verify
+################################################################################
+#
+# OVERVIEW
+# --------
+# Check that each submodule repo still exists on GitHub and hasn't been moved
+# or renamed. Uses `gh` CLI (must be authenticated).
+#
+# USAGE
+# -----
+#   bin/verify
+#
+################################################################################
+
+# Colors
+red='\033[0;31m'
+green='\033[0;32m'
+yellow='\033[1;33m'
+nc='\033[0m'
+
+################################################################################
+# Main Orchestration
+################################################################################
+
+main() {
+  local repos=()
+  local owner name
+  local total=0
+  local ok=0
+  local missing=()
+  local renamed=()
+
+  # Parse .gitmodules for repo URLs
+  while IFS= read -r url; do
+    if [[ "$url" =~ github\.com[:/]([^/]+)/([^/]+) ]]; then
+      owner="${BASH_REMATCH[1]}"
+      name="${BASH_REMATCH[2]}"
+      name="${name%.git}"
+      repos+=("${owner}/${name}")
+    fi
+  done < <(git config --file .gitmodules --get-regexp '\.url$' | cut -d' ' -f2)
+
+  total=${#repos[@]}
+  echo "Checking $total repos..."
+  echo ""
+
+  for i in "${!repos[@]}"; do
+    local expected="${repos[$i]}"
+    local idx=$((i + 1))
+
+    printf "%-60s (%d of %d)" "$expected" "$idx" "$total"
+
+    # Fetch canonical name; if repo is missing, gh exits non-zero
+    local actual
+    if actual=$(gh repo view "$expected" --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null); then
+      if [[ "$actual" == "$expected" ]]; then
+        echo -e " ${green}OK${nc}"
+        ok=$((ok + 1))
+      else
+        echo -e " ${yellow}RENAMED -> $actual${nc}"
+        renamed+=("$expected -> $actual")
+      fi
+    else
+      echo -e " ${red}MISSING${nc}"
+      missing+=("$expected")
+    fi
+  done
+
+  # Summary
+  echo ""
+  echo "======================================"
+  echo "Summary"
+  echo "======================================"
+  echo "  Total:   $total"
+  echo -e "  OK:      ${green}$ok${nc}"
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    echo -e "  Missing: ${red}${#missing[@]}${nc}"
+    echo ""
+    echo -e "${red}Missing repos:${nc}"
+    for r in "${missing[@]}"; do
+      echo "  - $r"
+    done
+  else
+    echo "  Missing: 0"
+  fi
+
+  if [[ ${#renamed[@]} -gt 0 ]]; then
+    echo -e "  Renamed: ${yellow}${#renamed[@]}${nc}"
+    echo ""
+    echo -e "${yellow}Renamed/moved repos:${nc}"
+    for r in "${renamed[@]}"; do
+      echo "  - $r"
+    done
+  else
+    echo "  Renamed: 0"
+  fi
+  echo ""
+}
+
+################################################################################
+# Script Execution
+################################################################################
+
+main "$@"


### PR DESCRIPTION
Adds a new script that uses the `gh` CLI to verify each submodule repo still exists on GitHub and hasn't been moved or renamed.

**What it does:**
- Parses all URLs from `.gitmodules`
- Checks each repo with `gh repo view`
- Compares the canonical `nameWithOwner` against the expected name to detect renames
- Prints each repo as it's checked (e.g. `discourse/discourse (5 of 219)`)
- Prints a summary at the end listing missing and renamed repos

**Usage:**
```bash
bin/verify
```

Requirements: gh CLI (authenticated, to avoid rate-limiting)

Results from a recent run:

- 219 repos checked
- 181 OK
- 6 missing
- 32 renamed/moved
