### PR TITLE
Add missing repositories to repos.md

### DIFF
--- a/repos.md
+++ b/repos.md
@@ -137,6 +137,9 @@ An editor for digital case files.
 The first open source crowdfunding platform for creative projects in the world [http://catarse.me](http://catarse.me)  
 [https://github.com/catarse/catarse](https://github.com/catarse/catarse)
 
+### chatwoot
+[https://github.com/chatwoot/chatwoot](https://github.com/chatwoot/chatwoot)
+
 ### cfp-app
 Rails app for managing a conference CFP  
 [https://github.com/rubycentral/cfp-app](https://github.com/rubycentral/cfp-app)
@@ -144,6 +147,9 @@ Rails app for managing a conference CFP
 ### chartkick
 Create beautiful JavaScript charts with one line of Ruby [https://chartkick.com](https://chartkick.com)  
 [https://github.com/ankane/chartkick](https://github.com/ankane/chartkick)
+
+### classroom
+[https://github.com/github-education-resources/classroom](https://github.com/github-education-resources/classroom)
 
 ### cloudnet
 The Global Cloud Hosting Marketplace  
@@ -503,6 +509,9 @@ The open source API directory of community social services. [http://ohana-api-de
 :gem: :diamonds: Whitelabel Site for Ruby Communities [http://www.onruby.eu](http://www.onruby.eu)
 [https://github.com/rughh/on_ruby](https://github.com/rughh/on_ruby)
 
+### onebody
+[https://github.com/seven1m/onebody](https://github.com/seven1m/onebody)
+
 ### once-campfire
 Campfire is a self-hosted group chat system with rooms, @mentions, direct messages, and mobile clients. Built by 37signals. [https://once.com/campfire](https://once.com/campfire)
 [https://github.com/basecamp/once-campfire](https://github.com/basecamp/once-campfire)
@@ -770,6 +779,9 @@ A simple UI for browsing and inspecting diffs, and an API for runner scripts to 
 ### spree
 An open source eCommerce platform giving you full control and customizability. Modular and API-first. Build any eCommerce solution that your business requires. [https://spreecommerce.org](https://spreecommerce.org)  
 [https://github.com/spree/spree](https://github.com/spree/spree)
+
+### storytime
+[https://github.com/CultivateLabs/storytime](https://github.com/CultivateLabs/storytime)
 
 ### stripe_event
 Stripe webhook integration for Rails applications. [https://rubygems.org/gems/stripe_event](https://rubygems.org/gems/stripe_event)  

--- a/repos.md
+++ b/repos.md
@@ -138,6 +138,7 @@ The first open source crowdfunding platform for creative projects in the world [
 [https://github.com/catarse/catarse](https://github.com/catarse/catarse)
 
 ### chatwoot
+Open-source live-chat, email support, omni-channel desk. An alternative to Intercom, Zendesk, Salesforce Service Cloud etc.
 [https://github.com/chatwoot/chatwoot](https://github.com/chatwoot/chatwoot)
 
 ### cfp-app
@@ -149,6 +150,7 @@ Create beautiful JavaScript charts with one line of Ruby [https://chartkick.com]
 [https://github.com/ankane/chartkick](https://github.com/ankane/chartkick)
 
 ### classroom
+GitHub Classroom automates repository creation and access control, making it easy for teachers to distribute starter code and collect assignments on GitHub.
 [https://github.com/github-education-resources/classroom](https://github.com/github-education-resources/classroom)
 
 ### cloudnet
@@ -510,6 +512,7 @@ The open source API directory of community social services. [http://ohana-api-de
 [https://github.com/rughh/on_ruby](https://github.com/rughh/on_ruby)
 
 ### onebody
+Private member portal for churches, built with Ruby on Rails.
 [https://github.com/seven1m/onebody](https://github.com/seven1m/onebody)
 
 ### once-campfire
@@ -781,6 +784,7 @@ An open source eCommerce platform giving you full control and customizability. M
 [https://github.com/spree/spree](https://github.com/spree/spree)
 
 ### storytime
+Storytime is a Rails 4+ CMS and blogging engine, with a core focus on content. It is built and maintained by @cultivatelabs.
 [https://github.com/CultivateLabs/storytime](https://github.com/CultivateLabs/storytime)
 
 ### stripe_event


### PR DESCRIPTION
Adds the four repositories present in `.gitmodules` but missing from `repos.md`: Chatwoot, Classroom, OneBody, and Storytime.

The repository lists now contain the same 238 canonical GitHub repositories.