### PR TITLE
Track main branch for rubyevents and pagecord

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -863,9 +863,11 @@
 [submodule "apps/rubyevents"]
 	path = apps/rubyevents
 	url = https://github.com/rubyevents/rubyevents.git
+	branch = main
 [submodule "apps/pagecord"]
 	path = apps/pagecord
 	url = https://github.com/lylo/pagecord.git
+	branch = main
 [submodule "apps/otwarchive"]
 	path = apps/otwarchive
 	url = git@github.com:otwcode/otwarchive.git


### PR DESCRIPTION
Both entries had no `branch =` line, so `git submodule update --remote` fell back to `master`, which neither repo has. Sets `branch = main` for both.